### PR TITLE
Remove pkg-resources==0.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ lxml==4.6.3
 ntlm-auth==1.5.0
 oauthlib==3.1.1
 pip==21.0.1
-pkg-resources==0.0.0
 pycparser==2.20
 Pygments==2.9.0
 pytz==2021.1


### PR DESCRIPTION
I tried to install in a new machine, and this line gave me an error
It seems it's a bug when you run python inside a virtualenv in Ubuntu:
https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command